### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-JsonEdit Eclipse Plugin
+[DEPRECATED] JsonEdit Eclipse Plugin
 =======================
 
-A fork of the JsonEdit Plugin on [sourceforge](https://sourceforge.net/projects/eclipsejsonedit/)
-
-[![Build Status](https://secure.travis-ci.org/pulse00/Json-Eclipse-Plugin.png)](http://travis-ci.org/pulse00/Json-Eclipse-Plugin)
+Please use the root repository https://github.com/boothen/Json-Eclipse-Plugin instead.


### PR DESCRIPTION
The original code repository https://github.com/boothen/Json-Eclipse-Plugin now contains all the changes made by @pulse00 

I think that it should be marked as root repository, too. To indicate that, I suggest adding a deprecation notice or even close this repo. as suggested here: https://github.com/pulse00/Json-Eclipse-Plugin/pull/1#issuecomment-11638508
